### PR TITLE
Add infrastructure and fix CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,12 @@ name: 'Terraform'
 on:
   push:
     branches: [ "main" ]
-    paths: '**.tf'
+    paths:
+      - '**.tf'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '**.tf'
 
 permissions:
   contents: read
@@ -12,30 +17,32 @@ jobs:
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-latest
-    
+
     defaults:
       run:
         shell: bash
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v3
       with:
         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
       run: terraform init
 
-    # Generates an execution plan for Terraform
+    - name: Terraform Format
+      run: terraform fmt -check
+
+    - name: Terraform Validate
+      run: terraform validate
+
     - name: Terraform Plan
       run: terraform plan -input=false
 
-      # Build or change infrastructure according to Terraform configuration files
     - name: Terraform Apply
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       run: terraform apply -auto-approve -input=false

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       "source" = "hashicorp/azurerm"
-      version  = "3.43.0"
+      version  = "~> 3.43"
     }
   }
   cloud { 
@@ -22,9 +22,9 @@ provider "azurerm" {
 }
 
 resource "random_string" "uniquestring" {
-  length           = 20
-  special          = false
-  upper            = false
+  length  = 21
+  special = false
+  upper   = false
 }
 
 resource "azurerm_resource_group" "rg" {


### PR DESCRIPTION
## Summary
- Add Azure resource group, storage account, and Terraform Cloud backend configuration
- Fix CI workflow: update Actions versions (checkout v4, setup-terraform v3), fix paths filter syntax, add PR trigger with plan-only gate, and add `terraform fmt` and `terraform validate` steps
- Use flexible azurerm provider version constraint (`~> 3.43`) and fix storage account name length

## Test plan
- [ ] Verify GitHub Actions workflow triggers on PR
- [ ] Confirm `terraform init`, `fmt -check`, `validate`, and `plan` steps pass
- [ ] Verify `terraform apply` only runs on push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)